### PR TITLE
Feat: add LayerInfo in GameObject.Find, add error message in GameObject.Mange (modify)

### DIFF
--- a/Editor/Scripts/API/Tool/GameObject.Manage.cs
+++ b/Editor/Scripts/API/Tool/GameObject.Manage.cs
@@ -456,6 +456,15 @@ Duplicated instanceIDs:
                             Undo.RegisterCompleteObjectUndo(unityObject, $"Modify {unityObject.name}");
                         }
 
+                        // Check if the diff has neither fields nor props
+                        if ((gameObjectDiffs[i].fields == null || gameObjectDiffs[i].fields.Count == 0) &&
+                            (gameObjectDiffs[i].props == null || gameObjectDiffs[i].props.Count == 0))
+                        {
+                            stringBuilder.AppendLine($"[Error] GameObject {i}: Diff has neither fields nor props - no modifications to apply for GameObject '{go.name}'.");
+                            errorCount++;
+                            continue;
+                        }
+
                         var populateResult = Reflector.Instance.Populate(ref objToModify, gameObjectDiffs[i]);
                         var populateResultString = populateResult.ToString().Trim();
 

--- a/Editor/Scripts/API/Tool/GameObject.Query.cs
+++ b/Editor/Scripts/API/Tool/GameObject.Query.cs
@@ -106,7 +106,13 @@ Also, it returns Components preview just for the target GameObject.")]
 # Data:
 ```json
 {JsonUtils.Serialize(serializedGo)}
-```";
+```
+
+# Bounds:
+```json
+{JsonUtils.Serialize(go.CalculateBounds())}
+```
+";
                     }
                     catch (System.Exception ex)
                     {
@@ -126,9 +132,9 @@ Basic GameObject info: instanceID={go.GetInstanceID()}, name={go.name}, active={
 {JsonUtils.Serialize(componentsPreview)}
 ```
 
-# Bounds:
+# Layer Info:
 ```json
-{JsonUtils.Serialize(go.CalculateBounds())}
+{JsonUtils.Serialize(new { LayerIndex = go.layer, LayerName = LayerMask.LayerToName(go.layer) })}
 ```
 
 # Hierarchy:


### PR DESCRIPTION
 1. Add LayerInfo in GameObject.Find's return message
 2. Check the format of gameObjectDiffs of GameObject.Mange (modify). Throw error if they have neither `props` or `fields`.