### PR TITLE
Fix: GameObject.Manage (modify) adopts strict type checking strategy

### DIFF
--- a/Editor/Scripts/API/Tool/GameObject.Query.cs
+++ b/Editor/Scripts/API/Tool/GameObject.Query.cs
@@ -94,8 +94,11 @@ Also, it returns Components preview just for the target GameObject.")]
                 {
                     try
                     {
+
+                        Debug.Log($"go.GetType(): {go.GetType()}");
                         var serializedGo = Reflector.Instance.Serialize(
                             go,
+                            type: go.GetType(),
                             name: go.name,
                             recursive: true,
                             logger: McpPlugin.Instance.Logger
@@ -119,7 +122,7 @@ Also, it returns Components preview just for the target GameObject.")]
                         result += @$"
 
 # Data:
-⚠️ Component {go.name} serialization failed due to: {ex.Message}
+⚠️ Object {go.name} serialization failed due to: {ex.Message}
 Basic GameObject info: instanceID={go.GetInstanceID()}, name={go.name}, active={go.activeInHierarchy}
 ";
                     }

--- a/Editor/Scripts/API/Tool/GameObject.cs
+++ b/Editor/Scripts/API/Tool/GameObject.cs
@@ -42,6 +42,8 @@ namespace com.MiAO.Unity.MCP.Editor.API
                 => $"[Error] Invalid component property type '{serializedProperty.typeName}' for '{propertyInfo.Name}'. Expected '{propertyInfo.FieldType.FullName}'.";
             public static string InvalidComponentType(string typeName)
                 => $"[Error] Invalid component type '{typeName}'. It should be a valid Component Type.";
+            public static string ObjectIsNotCompatibleWithTargetType(string objectName, string targetTypeName)
+                => $"[Error] Object '{objectName}' is not compatible with the target type '{targetTypeName}'.";
             public static string NotFoundComponent(int componentInstanceID, IEnumerable<UnityEngine.Component> allComponents)
             {
                 var availableComponentsPreview = allComponents


### PR DESCRIPTION
Throw errors for invalid InstanceId and unassignable object types